### PR TITLE
Cast csr_default_handler to csr_handler_t to avoid sizeof(function) e…

### DIFF
--- a/source/instructions/csrtypeinsn.cpp
+++ b/source/instructions/csrtypeinsn.cpp
@@ -318,7 +318,7 @@ static void csr_satp_handler(Cpu& cpu, Decoder decoder, uint64_t csr, uint64_t r
 
 void csr::init_handler_array()
 {
-    std::fill(csr_handlers.begin(), csr_handlers.end(), csr_default_handler);
+    std::fill(csr_handlers.begin(), csr_handlers.end(), static_cast<csr_handler_t>(csr_default_handler));
     csr_handlers[Address::FCSR] = csr_fcsr_handler;
     csr_handlers[Address::FFLAGS] = csr_fflags_handler;
     csr_handlers[Address::FRM] = csr_frm_handler;


### PR DESCRIPTION
…rror

Problem:
  Calling std::fill(csr_handlers.begin(), csr_handlers.end(), csr_default_handler)
can cause template type deduction to treat the argument as a function type. The STL implementation uses sizeof(_Tp) internally, and applying sizeof to a function type is ill-formed, producing:
  invalid application of 'sizeof' to a function type